### PR TITLE
Disable roll selected when none selected

### DIFF
--- a/src/Scripts/CustomDiceScripts/BaseDie.gd
+++ b/src/Scripts/CustomDiceScripts/BaseDie.gd
@@ -112,6 +112,8 @@ func _on_input_event(_camera: Node, event: InputEvent, _event_position: Vector3,
 		_toggle_selection_status()
 
 func _toggle_selection_status() -> void:
+	if is_rolling:
+		return
 	is_selected = !is_selected  # Toggle selection status
 	Debugger.log(str("Die selected status: ", is_selected, ". Dice: ", self.name, ". Dice Face Value: ", get_face_value()))
 	if !is_selected:

--- a/src/Scripts/CustomDiceScripts/BaseDie.gd
+++ b/src/Scripts/CustomDiceScripts/BaseDie.gd
@@ -26,6 +26,7 @@ var normalTex = GlobalSettings.normalDiceTex
 var selectedTex = GlobalSettings.selectedDiceTex
 var diceBaseTex = GlobalSettings.dicebaseTex
 
+
 # Threshold for detecting the "upward" ray
 @export var up_threshold: float
 # Dictionary to associate raycast nodes with face values
@@ -119,6 +120,8 @@ func _toggle_selection_status() -> void:
 		dieMesh.set_surface_override_material(0,selectedTex)
 	if dice_ui_element != null:
 		dice_ui_element._toggle_texture()
+		
+	get_parent().diceSelected()
 
 var dice_ui_element
 func _set_dice_ui(_ui_element) -> void:

--- a/src/Scripts/OnlineDefaultGameScene/OG_dynamic_dice_container.gd
+++ b/src/Scripts/OnlineDefaultGameScene/OG_dynamic_dice_container.gd
@@ -167,6 +167,10 @@ func moveDiceInline() -> void:
 			iterator = 0
 			current_row -= 1
 
+func diceSelected() -> void:
+	var diceselected = get_selected_dice().size()
+	get_parent().selected_dice_checker(diceselected)
+
 func moveDiceInLine() -> void:
 	#move dice once read to an organized display on the board
 	pass

--- a/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
+++ b/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
@@ -637,5 +637,12 @@ func setup_game_environment(_game_settings: Dictionary) -> void:
 	else:
 		Debugger.log(str("Client Game Environment initialized with settings:", _game_settings))
 
+func selected_dice_checker(num: int) -> void:
+	#Invert selection variable
+	#Track how many dice in the game
+	#track if I'm in hand selection stage (don't enable if there)
+	
+	pass
+
 func returnToIntro()-> void:
 	SceneSwitcher.returnToIntro()

--- a/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
+++ b/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
@@ -216,7 +216,6 @@ func setup_selection() -> void:
 		hand_selection_done = false
 		Debugger.log(str("Host: ", isHost, " reached hand selection on roll_count: ", roll_count, " of max: ", max_rolls_per_round))
 		setDisableScoreBoardButtons(false)
-		self.selected_dice_checker(0)
 		if timedRounds:
 			GameUI.startTimer(baseTimer*2)
 		selectionmode = "hand"
@@ -226,6 +225,7 @@ func setup_selection() -> void:
 		other_player_roll_selection = false
 		Debugger.log(str("Host: ", isHost, " reached roll selection on roll_count: ", roll_count, " of max: ", max_rolls_per_round))
 		setDisableRollButtons(false)
+		selected_dice_checker(0)
 		if timedRounds:
 			GameUI.startTimer(baseTimer)
 		selectionmode = "roll"

--- a/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
+++ b/src/Scripts/OnlineDefaultGameScene/OG_game_manager.gd
@@ -216,9 +216,11 @@ func setup_selection() -> void:
 		hand_selection_done = false
 		Debugger.log(str("Host: ", isHost, " reached hand selection on roll_count: ", roll_count, " of max: ", max_rolls_per_round))
 		setDisableScoreBoardButtons(false)
+		self.selected_dice_checker(0)
 		if timedRounds:
 			GameUI.startTimer(baseTimer*2)
 		selectionmode = "hand"
+		
 	else:
 		roll_selection_done = false
 		other_player_roll_selection = false
@@ -637,12 +639,20 @@ func setup_game_environment(_game_settings: Dictionary) -> void:
 	else:
 		Debugger.log(str("Client Game Environment initialized with settings:", _game_settings))
 
-func selected_dice_checker(num: int) -> void:
-	#Invert selection variable
-	#Track how many dice in the game
-	#track if I'm in hand selection stage (don't enable if there)
+func selected_dice_checker(selected_num: int ) -> void:
+	var inverted = invertSelection
+	var dicecount = game_settings["dice_count"]
 	
-	pass
+	if roll_count >= max_rolls_per_round:
+		return
+	else:
+		if (!inverted and selected_num == 0) or (inverted and selected_num == dicecount):
+			rollSelected.disabled = true
+		else:
+			rollSelected.disabled = false
+	
+	
+	
 
 func returnToIntro()-> void:
 	SceneSwitcher.returnToIntro()


### PR DESCRIPTION
enabled a new feature where the Roll Selected button is disabled when nothing is selected, and when the invert selection setting is active, the roll selected button is also disabled when all dice are selected in game.